### PR TITLE
specify encoding per PEP0263

### DIFF
--- a/lib/globalweathernotificationheadlines.py
+++ b/lib/globalweathernotificationheadlines.py
@@ -1,3 +1,5 @@
+# This Python file uses the following encoding: utf-8
+
 """
 from: https:#callforcode.weather.com/doc/v3-global-weather-notification-headlines/
  


### PR DESCRIPTION
Fixes this error message:
$ python app.py
Traceback (most recent call last):
  File "app.py", line 2, in <module>
    import lib.globalweathernotificationheadlines
  File "/lib/globalweathernotificationheadlines.py", line 23
SyntaxError: Non-ASCII character '\xe2' in file /lib/globalweathernotificationheadlines.py on line 24, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details